### PR TITLE
Use e.originalEvent only if it exists.

### DIFF
--- a/script/lvl-drag-drop.js
+++ b/script/lvl-drag-drop.js
@@ -14,7 +14,8 @@ module.directive('lvlDraggable', ['$rootScope', 'uuid', function ($rootScope, uu
             }
             console.log(id);
             el.bind("dragstart", function (e) {
-                e.originalEvent.dataTransfer.setData('text', id);
+                var oe = e.originalEvent || e;
+                oe.dataTransfer.setData('text', id);
                 console.log('drag');
                 $rootScope.$emit("LVL-DRAG-START");
             });
@@ -44,7 +45,8 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function ($rootScope, u
                     e.preventDefault(); // Necessary. Allows us to drop.
                 }
 
-                e.originalEvent.dataTransfer.dropEffect = 'move';  // See the section on the DataTransfer object.
+                var oe = e.originalEvent || e;
+                oe.dataTransfer.dropEffect = 'move';  // See the section on the DataTransfer object.
                 return false;
             });
 
@@ -65,7 +67,8 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function ($rootScope, u
                 if (e.stopPropagation) {
                     e.stopPropagation(); // Necessary. Allows us to drop.
                 }
-                var data = e.originalEvent.dataTransfer.getData("text");
+                var oe = e.originalEvent || e;
+                var data = oe.dataTransfer.getData("text");
                 var dest = document.getElementById(id);
                 var src = document.getElementById(data);
 


### PR DESCRIPTION
Restores compatibility with jqLite implementation in Angular 1.2.x